### PR TITLE
Apply Mike Dicus's IUG 2026 note corrections

### DIFF
--- a/content/executive-panel.md
+++ b/content/executive-panel.md
@@ -18,15 +18,16 @@ description: "Open Q&A with Clarivate executive leadership on Sierra's future, V
 <div class="card">
   <p><strong>Panelists:</strong></p>
   <ul style="margin: 0.75rem 0 0 1.5rem;">
-    <li><strong>Yoav (&ldquo;Yo&rdquo;)</strong> &mdash; General Manager &amp; Senior Vice President, Software Group</li>
+    <li><strong>Yoel Goldenberg</strong> &mdash; General Manager &amp; Senior Vice President, Software Group (first IUG)</li>
+    <li><strong>Yariv Kursh</strong> &mdash; Senior Vice President of Sales, Software Group (previously General Manager)</li>
+    <li><strong>Ashley Barey</strong> &mdash; VP of Product Management (lost voice; first IUG, partnered closely with Yaniv on product + engineering)</li>
+    <li><strong>Yaniv Shmuel</strong> &mdash; VP of Engineering, Public (fourth IUG)</li>
+    <li><strong>Melissa Hilbert</strong> &mdash; VP, Global Professional Services, Software Group (~20+ years with the larger organization)</li>
     <li><strong>Matt Baker</strong> &mdash; Senior Director, Customer Care</li>
     <li><strong>Caroline Mason</strong> &mdash; Senior Director, Professional Services, Software Group (Innovative side, ~8 years)</li>
-    <li><strong>Melissa Hilbert</strong> &mdash; VP, Global Professional Services, Software Group (~20+ years with the larger organization)</li>
-    <li><strong>Noel</strong> &mdash; VP of Engineering, Public (fourth IUG)</li>
-    <li><strong>Gary</strong> &mdash; Sales perspective (introduced during Q&amp;A)</li>
     <li><strong>Caitlin Spears</strong> &mdash; Director, Customer Care</li>
-    <li><strong>[Unnamed]</strong> &mdash; VP of Product Management (lost voice; first IUG, partnered closely with Noel on product + engineering)</li>
   </ul>
+  <p style="margin-top: 0.75rem; font-size: 0.9rem; color: #666;"><em>Panelist roster confirmed by Mike Dicus (Clarivate). Some Q&amp;A attributions below appear as &ldquo;Yoav&rdquo; &mdash; per Mike, that refers to either Yoel Goldenberg or Yariv Kursh; the transcript could not be definitively disambiguated.</em></p>
 </div>
 
 <!-- Key Takeaways -->
@@ -51,7 +52,7 @@ description: "Open Q&A with Clarivate executive leadership on Sierra's future, V
 <h2>Panel Introductions</h2>
 
 <div class="card">
-  <p>Each panelist introduced themselves. Yoav opened by noting the uniqueness of IUG compared to other Clarivate events (IGeLU, Lona/North American academic event), calling IUG a standout community. Several panelists were attending IUG for the first time. Caitlin Spears plugged her support restructure session at 1:30 PM and the VP of Product Management encouraged attendees to attend the UX session before leaving.</p>
+  <p>Each panelist introduced themselves. Yoav opened by noting the uniqueness of IUG compared to other Clarivate events (IGeLU, Lona/North American academic event), calling IUG a standout community. Several panelists were attending IUG for the first time. Caitlin Spears plugged her support restructure session at 1:30 PM and Ashley Barey encouraged attendees to attend the UX session before leaving.</p>
 </div>
 
 <!-- Leadership Change Announcements -->
@@ -96,7 +97,7 @@ description: "Open Q&A with Clarivate executive leadership on Sierra's future, V
     <ul style="margin: 0.75rem 0 0 1.5rem;">
       <li>Leadership acknowledged academic Sierra customers are &ldquo;caught between two worlds&rdquo; &mdash; most academics attend IGeLU, so IUG is mostly public-focused</li>
       <li><strong>Course reserves and serials</strong> functionality exists in Sierra but is considered legacy; those features don&rsquo;t get strong enhancement traction due to small customer base</li>
-      <li>The VP of Product Management committed to taking this offline with the questioner and involving Mike (engineering) and Asaf (academic side)</li>
+      <li>Ashley Barey committed to taking this offline with the questioner and involving Mike (engineering) and Asaf (academic side)</li>
       <li>Discussed potentially organizing <strong>&ldquo;birds of a feather&rdquo; or table-talk sessions</strong> at future IUGs for academic attendees, specific consortium types, or regional groups</li>
     </ul>
   </div>
@@ -112,7 +113,7 @@ description: "Open Q&A with Clarivate executive leadership on Sierra's future, V
     <p>(LX Starter for email notifications, Interact for SMS, Promote for marketing, Discover for OPAC)</p>
   </div>
   <div class="section-item">
-    <h3>Product perspective (VP of Product Management)</h3>
+    <h3>Product perspective (Ashley Barey)</h3>
     <p>Acknowledged the current state honestly &mdash; Vega is a &ldquo;work in progress&rdquo; (used the metaphor of a &ldquo;mason&rdquo; &mdash; the building blocks are there but not fully connected yet). Investment is being made in <strong>three pillars:</strong></p>
     <ol style="margin: 0.75rem 0 0 1.5rem;">
       <li><strong>Access</strong> &mdash; Single sign-on (already completed); ensuring everyone can reach everything they need</li>
@@ -122,7 +123,7 @@ description: "Open Q&A with Clarivate executive leadership on Sierra's future, V
     <p style="margin-top: 0.75rem;"><strong>Road maps will be overhauled in the June time frame</strong> &mdash; more uniform presentation, three items per card plus comments, borrowing from the academic side&rsquo;s approach. Plans to add more ethnographic research to the roadmap process so customers can &ldquo;see themselves&rdquo; in planned features.</p>
   </div>
   <div class="section-item">
-    <h3>Engineering perspective (Noel)</h3>
+    <h3>Engineering perspective (Yaniv Shmuel)</h3>
     <p>The platform approach means building shared foundations &mdash; e.g., <strong><a href="vega-reports.html">Vega Reports</a> serves both Polaris and Sierra</strong> without needing separate development. The goal is that individual Vega products (LX Starter, Interact, etc.) will eventually be a seamless out-of-the-box experience &mdash; &ldquo;a click of a button, you don&rsquo;t need to install anything.&rdquo; Focused on creating solutions that work for <strong>both Polaris and Sierra</strong> customer bases.</p>
   </div>
 </div>
@@ -257,6 +258,6 @@ description: "Open Q&A with Clarivate executive leadership on Sierra's future, V
     <li><strong>Caitlin Spears&rsquo; Support Restructure Session</strong> &mdash; Wednesday 1:30 PM, detailed announcement of tiered support for Polaris <em>(notes not yet captured)</em></li>
     <li><strong><a href="vega-reports.html">Vega Reports and Analytics</a></strong> &mdash; Tuesday session covering Vega Reports for Discover, Polaris, and Sierra</li>
     <li><strong><a href="ai-the-right-way.html">AI The Right Way</a></strong> &mdash; Tuesday session on Clarivate&rsquo;s responsible AI approach</li>
-    <li><strong>UX Session</strong> &mdash; referenced by the VP of Product Management (time/room not specified in transcript)</li>
+    <li><strong>UX Session</strong> &mdash; referenced by Ashley Barey (time/room not specified in transcript)</li>
     <li><strong>NYPL (New York Public Library)</strong> &mdash; also noted as an early adopter <em>(per Jeremy; specific product/initiative TBD)</em></li>
   </ul>

--- a/content/meep.md
+++ b/content/meep.md
@@ -178,8 +178,8 @@ Product managers work with their teams to estimate development effort in points:
 
 ### Sierra 6.6
 
-- Ability to cover/apply for multi-volume records
-- Add permission to prevent bulk deletion of notice table
+- View history of item and volume records
+- Separate permissions to create/edit/delete notice jobs and prepare/run notices
 
 ### Sierra 6.7
 

--- a/content/sierra-roadmap.md
+++ b/content/sierra-roadmap.md
@@ -78,10 +78,10 @@ Theme: **Customer-driven enhancements** — sourced from MEEP, Idea Exchange, an
       <td>New permissions to delete notice jobs</td>
       <td>Run notice jobs automatically</td>
       <td>Admin Console for Vega Reports</td>
-      <td>Enhanced consortial workflow support</td>
+      <td>Enhance support for exhibitions in IMMS</td>
     </tr>
     <tr>
-      <td>Customize SAML login forms (webmaster-controlled branding). Keycloak (currently powering Vega identity) may become a shared service across Sierra/Polaris/Vega.</td>
+      <td>Customize SAML login forms (webmaster-controlled branding).</td>
       <td>Accessibility improvements in staff client and WebPAC</td>
       <td>Group call numbers for statistical reports (stat groups)</td>
       <td>Rapido / consortial borrowing &mdash; pickup location data, filling gaps</td>
@@ -144,9 +144,9 @@ Theme: **Customer-driven enhancements** — sourced from MEEP, Idea Exchange, an
 
 <div class="card">
   <ul style="padding-left: 1.25rem; margin: 0;">
-    <li>Apply barcode print specifications for labels generated from login and Automated EDI interface</li>
-    <li>No title due on verify slips when patron has a hold/ILL</li>
-    <li>Generate clean and automated reporting for statistics</li>
+    <li>Apply reusable print templates to spine labels generated from Create Lists</li>
+    <li>Automatic SSL certificate renewal</li>
+    <li>Update last circ activity date when patrons use eVendors</li>
   </ul>
 </div>
 

--- a/content/sierra-sys-admin-forum.md
+++ b/content/sierra-sys-admin-forum.md
@@ -211,7 +211,7 @@ description: "Open forum for Sierra system administrators covering migration con
   </div>
   <div class="section-item">
     <h3>New API enhancement</h3>
-    <p><strong>Mike Dykus (Clarivate) confirmed a new API enhancement coming:</strong> for e-vendors (Hoopla, Overdrive) validating patrons, the record won&rsquo;t get its &ldquo;last updated&rdquo; date changed, but the circ active date can be set to indicate the patron is using e-resources. However, it does <strong>not</strong> take a date parameter to backdate. Toggle is &ldquo;all or nothing.&rdquo;</p>
+    <p><strong>Mike Dicus (Clarivate) confirmed a new API enhancement coming:</strong> for e-vendors (Hoopla, Overdrive) validating patrons, the record won&rsquo;t get its &ldquo;last updated&rdquo; date changed, but the circ active date can be set to indicate the patron is using e-resources. However, it does <strong>not</strong> take a date parameter to backdate. Toggle is &ldquo;all or nothing.&rdquo;</p>
     <p><strong>Action item:</strong> everyone should contact Hoopla/Overdrive to push them to adopt the new validation method.</p>
     <p>Someone has a script workaround for this issue.</p>
   </div>

--- a/content/sierra-year-in-review.md
+++ b/content/sierra-year-in-review.md
@@ -166,7 +166,7 @@ description: "Sierra 6.4 and 6.5 release highlights: patron checkout limits, inv
     </thead>
     <tbody>
       <tr><td>Locations served limit doubled</td><td>From 1,000 to <strong>2,000</strong> location codes per entry</td></tr>
-      <tr><td>SQS connection test for notices</td><td>Tests connectivity before sending notice data to Alma Starter; prevents data loss</td></tr>
+      <tr><td>SQS connection test for notices</td><td>Tests connectivity before sending notice data to LX Starter; prevents data loss</td></tr>
       <tr><td>Accessibility improvements</td><td>Name, role, and value attributes set for fields in circulation and search screens</td></tr>
       <tr><td>Client branding update</td><td><strong>Glacier Point</strong>: light gray theme. <strong>Half Dome</strong>: dark theme. Switchable via <em>Settings &rarr; Display</em>.</td></tr>
     </tbody>
@@ -177,7 +177,7 @@ description: "Sierra 6.4 and 6.5 release highlights: patron checkout limits, inv
 
 <div class="card">
   <ul>
-    <li><strong>Product Roadmap Portal</strong> &mdash; vote on features from &ldquo;not important&rdquo; to &ldquo;critically important&rdquo; and add comments <em>(customer login required)</em></li>
+    <li><strong>Public Roadmap</strong> &mdash; vote on features from &ldquo;not important&rdquo; to &ldquo;critically important&rdquo; and add comments</li>
     <li><strong>Idea Exchange</strong> &mdash; submit and vote on ideas
       <ul>
         <li>120+ users/day average</li>
@@ -192,10 +192,12 @@ description: "Sierra 6.4 and 6.5 release highlights: patron checkout limits, inv
 
   <h3>Links</h3>
   <ul>
-    <li><a href="https://www.iii.com/resources/webinars/">Webinars &amp; Recordings</a></li>
-    <li><a href="https://iii.com/roadmap/">Product Roadmap Portal</a> <em>(customer login required)</em></li>
-    <li><a href="https://ideaexchange.iii.com/">Idea Exchange</a></li>
+    <li><a href="https://www.iii.com/webinars/">Webinars</a></li>
+    <li><a href="https://knowledge.ag-software.clarivate.com/kp/index.htm">Knowledge Portal</a></li>
+    <li><a href="https://portal.productboard.com/iii/">Public Roadmap</a></li>
+    <li><a href="https://ideas.iii.com/">Idea Exchange</a> <em>(login required only to post a new idea)</em></li>
   </ul>
+  <p><em>All four channels are publicly available without a login.</em></p>
 </div>
 
 ## Slide Photos

--- a/docs/executive-panel.html
+++ b/docs/executive-panel.html
@@ -72,15 +72,16 @@
 <div class="card">
 <p><strong>Panelists:</strong></p>
 <ul style="margin: 0.75rem 0 0 1.5rem;">
-<li><strong>Yoav (&ldquo;Yo&rdquo;)</strong> &mdash; General Manager &amp; Senior Vice President, Software Group</li>
+<li><strong>Yoel Goldenberg</strong> &mdash; General Manager &amp; Senior Vice President, Software Group (first IUG)</li>
+<li><strong>Yariv Kursh</strong> &mdash; Senior Vice President of Sales, Software Group (previously General Manager)</li>
+<li><strong>Ashley Barey</strong> &mdash; VP of Product Management (lost voice; first IUG, partnered closely with Yaniv on product + engineering)</li>
+<li><strong>Yaniv Shmuel</strong> &mdash; VP of Engineering, Public (fourth IUG)</li>
+<li><strong>Melissa Hilbert</strong> &mdash; VP, Global Professional Services, Software Group (~20+ years with the larger organization)</li>
 <li><strong>Matt Baker</strong> &mdash; Senior Director, Customer Care</li>
 <li><strong>Caroline Mason</strong> &mdash; Senior Director, Professional Services, Software Group (Innovative side, ~8 years)</li>
-<li><strong>Melissa Hilbert</strong> &mdash; VP, Global Professional Services, Software Group (~20+ years with the larger organization)</li>
-<li><strong>Noel</strong> &mdash; VP of Engineering, Public (fourth IUG)</li>
-<li><strong>Gary</strong> &mdash; Sales perspective (introduced during Q&amp;A)</li>
 <li><strong>Caitlin Spears</strong> &mdash; Director, Customer Care</li>
-<li><strong>[Unnamed]</strong> &mdash; VP of Product Management (lost voice; first IUG, partnered closely with Noel on product + engineering)</li>
 </ul>
+<p style="margin-top: 0.75rem; font-size: 0.9rem; color: #666;"><em>Panelist roster confirmed by Mike Dicus (Clarivate). Some Q&amp;A attributions below appear as &ldquo;Yoav&rdquo; &mdash; per Mike, that refers to either Yoel Goldenberg or Yariv Kursh; the transcript could not be definitively disambiguated.</em></p>
 </div>
 
 <!-- Key Takeaways -->
@@ -105,7 +106,7 @@
 <h2>Panel Introductions</h2>
 
 <div class="card">
-<p>Each panelist introduced themselves. Yoav opened by noting the uniqueness of IUG compared to other Clarivate events (IGeLU, Lona/North American academic event), calling IUG a standout community. Several panelists were attending IUG for the first time. Caitlin Spears plugged her support restructure session at 1:30 PM and the VP of Product Management encouraged attendees to attend the UX session before leaving.</p>
+<p>Each panelist introduced themselves. Yoav opened by noting the uniqueness of IUG compared to other Clarivate events (IGeLU, Lona/North American academic event), calling IUG a standout community. Several panelists were attending IUG for the first time. Caitlin Spears plugged her support restructure session at 1:30 PM and Ashley Barey encouraged attendees to attend the UX session before leaving.</p>
 </div>
 
 <!-- Leadership Change Announcements -->
@@ -150,7 +151,7 @@
 <ul style="margin: 0.75rem 0 0 1.5rem;">
 <li>Leadership acknowledged academic Sierra customers are &ldquo;caught between two worlds&rdquo; &mdash; most academics attend IGeLU, so IUG is mostly public-focused</li>
 <li><strong>Course reserves and serials</strong> functionality exists in Sierra but is considered legacy; those features don&rsquo;t get strong enhancement traction due to small customer base</li>
-<li>The VP of Product Management committed to taking this offline with the questioner and involving Mike (engineering) and Asaf (academic side)</li>
+<li>Ashley Barey committed to taking this offline with the questioner and involving Mike (engineering) and Asaf (academic side)</li>
 <li>Discussed potentially organizing <strong>&ldquo;birds of a feather&rdquo; or table-talk sessions</strong> at future IUGs for academic attendees, specific consortium types, or regional groups</li>
 </ul>
 </div>
@@ -166,7 +167,7 @@
 <p>(LX Starter for email notifications, Interact for SMS, Promote for marketing, Discover for OPAC)</p>
 </div>
 <div class="section-item">
-<h3>Product perspective (VP of Product Management)</h3>
+<h3>Product perspective (Ashley Barey)</h3>
 <p>Acknowledged the current state honestly &mdash; Vega is a &ldquo;work in progress&rdquo; (used the metaphor of a &ldquo;mason&rdquo; &mdash; the building blocks are there but not fully connected yet). Investment is being made in <strong>three pillars:</strong></p>
 <ol style="margin: 0.75rem 0 0 1.5rem;">
 <li><strong>Access</strong> &mdash; Single sign-on (already completed); ensuring everyone can reach everything they need</li>
@@ -176,7 +177,7 @@
 <p style="margin-top: 0.75rem;"><strong>Road maps will be overhauled in the June time frame</strong> &mdash; more uniform presentation, three items per card plus comments, borrowing from the academic side&rsquo;s approach. Plans to add more ethnographic research to the roadmap process so customers can &ldquo;see themselves&rdquo; in planned features.</p>
 </div>
 <div class="section-item">
-<h3>Engineering perspective (Noel)</h3>
+<h3>Engineering perspective (Yaniv Shmuel)</h3>
 <p>The platform approach means building shared foundations &mdash; e.g., <strong><a href="vega-reports.html">Vega Reports</a> serves both Polaris and Sierra</strong> without needing separate development. The goal is that individual Vega products (LX Starter, Interact, etc.) will eventually be a seamless out-of-the-box experience &mdash; &ldquo;a click of a button, you don&rsquo;t need to install anything.&rdquo; Focused on creating solutions that work for <strong>both Polaris and Sierra</strong> customer bases.</p>
 </div>
 </div>
@@ -311,7 +312,7 @@
 <li><strong>Caitlin Spears&rsquo; Support Restructure Session</strong> &mdash; Wednesday 1:30 PM, detailed announcement of tiered support for Polaris <em>(notes not yet captured)</em></li>
 <li><strong><a href="vega-reports.html">Vega Reports and Analytics</a></strong> &mdash; Tuesday session covering Vega Reports for Discover, Polaris, and Sierra</li>
 <li><strong><a href="ai-the-right-way.html">AI The Right Way</a></strong> &mdash; Tuesday session on Clarivate&rsquo;s responsible AI approach</li>
-<li><strong>UX Session</strong> &mdash; referenced by the VP of Product Management (time/room not specified in transcript)</li>
+<li><strong>UX Session</strong> &mdash; referenced by Ashley Barey (time/room not specified in transcript)</li>
 <li><strong>NYPL (New York Public Library)</strong> &mdash; also noted as an early adopter <em>(per Jeremy; specific product/initiative TBD)</em></li>
 </ul>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1983,15 +1983,16 @@ Description: Open Q&A with Clarivate executive leadership on Sierra's future, Ve
 <div class="card">
   <p><strong>Panelists:</strong></p>
   <ul style="margin: 0.75rem 0 0 1.5rem;">
-    <li><strong>Yoav (&ldquo;Yo&rdquo;)</strong> &mdash; General Manager &amp; Senior Vice President, Software Group</li>
+    <li><strong>Yoel Goldenberg</strong> &mdash; General Manager &amp; Senior Vice President, Software Group (first IUG)</li>
+    <li><strong>Yariv Kursh</strong> &mdash; Senior Vice President of Sales, Software Group (previously General Manager)</li>
+    <li><strong>Ashley Barey</strong> &mdash; VP of Product Management (lost voice; first IUG, partnered closely with Yaniv on product + engineering)</li>
+    <li><strong>Yaniv Shmuel</strong> &mdash; VP of Engineering, Public (fourth IUG)</li>
+    <li><strong>Melissa Hilbert</strong> &mdash; VP, Global Professional Services, Software Group (~20+ years with the larger organization)</li>
     <li><strong>Matt Baker</strong> &mdash; Senior Director, Customer Care</li>
     <li><strong>Caroline Mason</strong> &mdash; Senior Director, Professional Services, Software Group (Innovative side, ~8 years)</li>
-    <li><strong>Melissa Hilbert</strong> &mdash; VP, Global Professional Services, Software Group (~20+ years with the larger organization)</li>
-    <li><strong>Noel</strong> &mdash; VP of Engineering, Public (fourth IUG)</li>
-    <li><strong>Gary</strong> &mdash; Sales perspective (introduced during Q&amp;A)</li>
     <li><strong>Caitlin Spears</strong> &mdash; Director, Customer Care</li>
-    <li><strong>[Unnamed]</strong> &mdash; VP of Product Management (lost voice; first IUG, partnered closely with Noel on product + engineering)</li>
   </ul>
+  <p style="margin-top: 0.75rem; font-size: 0.9rem; color: #666;"><em>Panelist roster confirmed by Mike Dicus (Clarivate). Some Q&amp;A attributions below appear as &ldquo;Yoav&rdquo; &mdash; per Mike, that refers to either Yoel Goldenberg or Yariv Kursh; the transcript could not be definitively disambiguated.</em></p>
 </div>
 
 <!-- Key Takeaways -->
@@ -2016,7 +2017,7 @@ Description: Open Q&A with Clarivate executive leadership on Sierra's future, Ve
 <h2>Panel Introductions</h2>
 
 <div class="card">
-  <p>Each panelist introduced themselves. Yoav opened by noting the uniqueness of IUG compared to other Clarivate events (IGeLU, Lona/North American academic event), calling IUG a standout community. Several panelists were attending IUG for the first time. Caitlin Spears plugged her support restructure session at 1:30 PM and the VP of Product Management encouraged attendees to attend the UX session before leaving.</p>
+  <p>Each panelist introduced themselves. Yoav opened by noting the uniqueness of IUG compared to other Clarivate events (IGeLU, Lona/North American academic event), calling IUG a standout community. Several panelists were attending IUG for the first time. Caitlin Spears plugged her support restructure session at 1:30 PM and Ashley Barey encouraged attendees to attend the UX session before leaving.</p>
 </div>
 
 <!-- Leadership Change Announcements -->
@@ -2061,7 +2062,7 @@ Description: Open Q&A with Clarivate executive leadership on Sierra's future, Ve
     <ul style="margin: 0.75rem 0 0 1.5rem;">
       <li>Leadership acknowledged academic Sierra customers are &ldquo;caught between two worlds&rdquo; &mdash; most academics attend IGeLU, so IUG is mostly public-focused</li>
       <li><strong>Course reserves and serials</strong> functionality exists in Sierra but is considered legacy; those features don&rsquo;t get strong enhancement traction due to small customer base</li>
-      <li>The VP of Product Management committed to taking this offline with the questioner and involving Mike (engineering) and Asaf (academic side)</li>
+      <li>Ashley Barey committed to taking this offline with the questioner and involving Mike (engineering) and Asaf (academic side)</li>
       <li>Discussed potentially organizing <strong>&ldquo;birds of a feather&rdquo; or table-talk sessions</strong> at future IUGs for academic attendees, specific consortium types, or regional groups</li>
     </ul>
   </div>
@@ -2077,7 +2078,7 @@ Description: Open Q&A with Clarivate executive leadership on Sierra's future, Ve
     <p>(LX Starter for email notifications, Interact for SMS, Promote for marketing, Discover for OPAC)</p>
   </div>
   <div class="section-item">
-    <h3>Product perspective (VP of Product Management)</h3>
+    <h3>Product perspective (Ashley Barey)</h3>
     <p>Acknowledged the current state honestly &mdash; Vega is a &ldquo;work in progress&rdquo; (used the metaphor of a &ldquo;mason&rdquo; &mdash; the building blocks are there but not fully connected yet). Investment is being made in <strong>three pillars:</strong></p>
     <ol style="margin: 0.75rem 0 0 1.5rem;">
       <li><strong>Access</strong> &mdash; Single sign-on (already completed); ensuring everyone can reach everything they need</li>
@@ -2087,7 +2088,7 @@ Description: Open Q&A with Clarivate executive leadership on Sierra's future, Ve
     <p style="margin-top: 0.75rem;"><strong>Road maps will be overhauled in the June time frame</strong> &mdash; more uniform presentation, three items per card plus comments, borrowing from the academic side&rsquo;s approach. Plans to add more ethnographic research to the roadmap process so customers can &ldquo;see themselves&rdquo; in planned features.</p>
   </div>
   <div class="section-item">
-    <h3>Engineering perspective (Noel)</h3>
+    <h3>Engineering perspective (Yaniv Shmuel)</h3>
     <p>The platform approach means building shared foundations &mdash; e.g., <strong><a href="vega-reports.html">Vega Reports</a> serves both Polaris and Sierra</strong> without needing separate development. The goal is that individual Vega products (LX Starter, Interact, etc.) will eventually be a seamless out-of-the-box experience &mdash; &ldquo;a click of a button, you don&rsquo;t need to install anything.&rdquo; Focused on creating solutions that work for <strong>both Polaris and Sierra</strong> customer bases.</p>
   </div>
 </div>
@@ -2222,7 +2223,7 @@ Description: Open Q&A with Clarivate executive leadership on Sierra's future, Ve
     <li><strong>Caitlin Spears&rsquo; Support Restructure Session</strong> &mdash; Wednesday 1:30 PM, detailed announcement of tiered support for Polaris <em>(notes not yet captured)</em></li>
     <li><strong><a href="vega-reports.html">Vega Reports and Analytics</a></strong> &mdash; Tuesday session covering Vega Reports for Discover, Polaris, and Sierra</li>
     <li><strong><a href="ai-the-right-way.html">AI The Right Way</a></strong> &mdash; Tuesday session on Clarivate&rsquo;s responsible AI approach</li>
-    <li><strong>UX Session</strong> &mdash; referenced by the VP of Product Management (time/room not specified in transcript)</li>
+    <li><strong>UX Session</strong> &mdash; referenced by Ashley Barey (time/room not specified in transcript)</li>
     <li><strong>NYPL (New York Public Library)</strong> &mdash; also noted as an early adopter <em>(per Jeremy; specific product/initiative TBD)</em></li>
   </ul>
 
@@ -2963,8 +2964,8 @@ Product managers work with their teams to estimate development effort in points:
 
 ### Sierra 6.6
 
-- Ability to cover/apply for multi-volume records
-- Add permission to prevent bulk deletion of notice table
+- View history of item and volume records
+- Separate permissions to create/edit/delete notice jobs and prepare/run notices
 
 ### Sierra 6.7
 
@@ -3426,10 +3427,10 @@ Theme: **Customer-driven enhancements** — sourced from MEEP, Idea Exchange, an
       <td>New permissions to delete notice jobs</td>
       <td>Run notice jobs automatically</td>
       <td>Admin Console for Vega Reports</td>
-      <td>Enhanced consortial workflow support</td>
+      <td>Enhance support for exhibitions in IMMS</td>
     </tr>
     <tr>
-      <td>Customize SAML login forms (webmaster-controlled branding). Keycloak (currently powering Vega identity) may become a shared service across Sierra/Polaris/Vega.</td>
+      <td>Customize SAML login forms (webmaster-controlled branding).</td>
       <td>Accessibility improvements in staff client and WebPAC</td>
       <td>Group call numbers for statistical reports (stat groups)</td>
       <td>Rapido / consortial borrowing &mdash; pickup location data, filling gaps</td>
@@ -3492,9 +3493,9 @@ Theme: **Customer-driven enhancements** — sourced from MEEP, Idea Exchange, an
 
 <div class="card">
   <ul style="padding-left: 1.25rem; margin: 0;">
-    <li>Apply barcode print specifications for labels generated from login and Automated EDI interface</li>
-    <li>No title due on verify slips when patron has a hold/ILL</li>
-    <li>Generate clean and automated reporting for statistics</li>
+    <li>Apply reusable print templates to spine labels generated from Create Lists</li>
+    <li>Automatic SSL certificate renewal</li>
+    <li>Update last circ activity date when patrons use eVendors</li>
   </ul>
 </div>
 
@@ -5141,7 +5142,7 @@ Description: Open forum for Sierra system administrators covering migration cons
   </div>
   <div class="section-item">
     <h3>New API enhancement</h3>
-    <p><strong>Mike Dykus (Clarivate) confirmed a new API enhancement coming:</strong> for e-vendors (Hoopla, Overdrive) validating patrons, the record won&rsquo;t get its &ldquo;last updated&rdquo; date changed, but the circ active date can be set to indicate the patron is using e-resources. However, it does <strong>not</strong> take a date parameter to backdate. Toggle is &ldquo;all or nothing.&rdquo;</p>
+    <p><strong>Mike Dicus (Clarivate) confirmed a new API enhancement coming:</strong> for e-vendors (Hoopla, Overdrive) validating patrons, the record won&rsquo;t get its &ldquo;last updated&rdquo; date changed, but the circ active date can be set to indicate the patron is using e-resources. However, it does <strong>not</strong> take a date parameter to backdate. Toggle is &ldquo;all or nothing.&rdquo;</p>
     <p><strong>Action item:</strong> everyone should contact Hoopla/Overdrive to push them to adopt the new validation method.</p>
     <p>Someone has a script workaround for this issue.</p>
   </div>
@@ -5494,7 +5495,7 @@ Description: Sierra 6.4 and 6.5 release highlights: patron checkout limits, inve
     </thead>
     <tbody>
       <tr><td>Locations served limit doubled</td><td>From 1,000 to <strong>2,000</strong> location codes per entry</td></tr>
-      <tr><td>SQS connection test for notices</td><td>Tests connectivity before sending notice data to Alma Starter; prevents data loss</td></tr>
+      <tr><td>SQS connection test for notices</td><td>Tests connectivity before sending notice data to LX Starter; prevents data loss</td></tr>
       <tr><td>Accessibility improvements</td><td>Name, role, and value attributes set for fields in circulation and search screens</td></tr>
       <tr><td>Client branding update</td><td><strong>Glacier Point</strong>: light gray theme. <strong>Half Dome</strong>: dark theme. Switchable via <em>Settings &rarr; Display</em>.</td></tr>
     </tbody>
@@ -5505,7 +5506,7 @@ Description: Sierra 6.4 and 6.5 release highlights: patron checkout limits, inve
 
 <div class="card">
   <ul>
-    <li><strong>Product Roadmap Portal</strong> &mdash; vote on features from &ldquo;not important&rdquo; to &ldquo;critically important&rdquo; and add comments <em>(customer login required)</em></li>
+    <li><strong>Public Roadmap</strong> &mdash; vote on features from &ldquo;not important&rdquo; to &ldquo;critically important&rdquo; and add comments</li>
     <li><strong>Idea Exchange</strong> &mdash; submit and vote on ideas
       <ul>
         <li>120+ users/day average</li>
@@ -5520,10 +5521,12 @@ Description: Sierra 6.4 and 6.5 release highlights: patron checkout limits, inve
 
   <h3>Links</h3>
   <ul>
-    <li><a href="https://www.iii.com/resources/webinars/">Webinars &amp; Recordings</a></li>
-    <li><a href="https://iii.com/roadmap/">Product Roadmap Portal</a> <em>(customer login required)</em></li>
-    <li><a href="https://ideaexchange.iii.com/">Idea Exchange</a></li>
+    <li><a href="https://www.iii.com/webinars/">Webinars</a></li>
+    <li><a href="https://knowledge.ag-software.clarivate.com/kp/index.htm">Knowledge Portal</a></li>
+    <li><a href="https://portal.productboard.com/iii/">Public Roadmap</a></li>
+    <li><a href="https://ideas.iii.com/">Idea Exchange</a> <em>(login required only to post a new idea)</em></li>
   </ul>
+  <p><em>All four channels are publicly available without a login.</em></p>
 </div>
 
 ## Slide Photos

--- a/docs/meep.html
+++ b/docs/meep.html
@@ -225,8 +225,8 @@
 </ul>
 <h3>Sierra 6.6</h3>
 <ul>
-<li>Ability to cover/apply for multi-volume records</li>
-<li>Add permission to prevent bulk deletion of notice table</li>
+<li>View history of item and volume records</li>
+<li>Separate permissions to create/edit/delete notice jobs and prepare/run notices</li>
 </ul>
 <h3>Sierra 6.7</h3>
 <ul>

--- a/docs/sierra-roadmap.html
+++ b/docs/sierra-roadmap.html
@@ -128,10 +128,10 @@
 <td>New permissions to delete notice jobs</td>
 <td>Run notice jobs automatically</td>
 <td>Admin Console for Vega Reports</td>
-<td>Enhanced consortial workflow support</td>
+<td>Enhance support for exhibitions in IMMS</td>
 </tr>
 <tr>
-<td>Customize SAML login forms (webmaster-controlled branding). Keycloak (currently powering Vega identity) may become a shared service across Sierra/Polaris/Vega.</td>
+<td>Customize SAML login forms (webmaster-controlled branding).</td>
 <td>Accessibility improvements in staff client and WebPAC</td>
 <td>Group call numbers for statistical reports (stat groups)</td>
 <td>Rapido / consortial borrowing &mdash; pickup location data, filling gaps</td>
@@ -192,9 +192,9 @@
 <h2>MEEP Enhancements — March 2026 Voting Results</h2>
 <div class="card">
 <ul style="padding-left: 1.25rem; margin: 0;">
-<li>Apply barcode print specifications for labels generated from login and Automated EDI interface</li>
-<li>No title due on verify slips when patron has a hold/ILL</li>
-<li>Generate clean and automated reporting for statistics</li>
+<li>Apply reusable print templates to spine labels generated from Create Lists</li>
+<li>Automatic SSL certificate renewal</li>
+<li>Update last circ activity date when patrons use eVendors</li>
 </ul>
 </div>
 

--- a/docs/sierra-sys-admin-forum.html
+++ b/docs/sierra-sys-admin-forum.html
@@ -265,7 +265,7 @@
 </div>
 <div class="section-item">
 <h3>New API enhancement</h3>
-<p><strong>Mike Dykus (Clarivate) confirmed a new API enhancement coming:</strong> for e-vendors (Hoopla, Overdrive) validating patrons, the record won&rsquo;t get its &ldquo;last updated&rdquo; date changed, but the circ active date can be set to indicate the patron is using e-resources. However, it does <strong>not</strong> take a date parameter to backdate. Toggle is &ldquo;all or nothing.&rdquo;</p>
+<p><strong>Mike Dicus (Clarivate) confirmed a new API enhancement coming:</strong> for e-vendors (Hoopla, Overdrive) validating patrons, the record won&rsquo;t get its &ldquo;last updated&rdquo; date changed, but the circ active date can be set to indicate the patron is using e-resources. However, it does <strong>not</strong> take a date parameter to backdate. Toggle is &ldquo;all or nothing.&rdquo;</p>
 <p><strong>Action item:</strong> everyone should contact Hoopla/Overdrive to push them to adopt the new validation method.</p>
 <p>Someone has a script workaround for this issue.</p>
 </div>

--- a/docs/sierra-year-in-review.html
+++ b/docs/sierra-year-in-review.html
@@ -207,7 +207,7 @@
 </thead>
 <tbody>
 <tr><td>Locations served limit doubled</td><td>From 1,000 to <strong>2,000</strong> location codes per entry</td></tr>
-<tr><td>SQS connection test for notices</td><td>Tests connectivity before sending notice data to Alma Starter; prevents data loss</td></tr>
+<tr><td>SQS connection test for notices</td><td>Tests connectivity before sending notice data to LX Starter; prevents data loss</td></tr>
 <tr><td>Accessibility improvements</td><td>Name, role, and value attributes set for fields in circulation and search screens</td></tr>
 <tr><td>Client branding update</td><td><strong>Glacier Point</strong>: light gray theme. <strong>Half Dome</strong>: dark theme. Switchable via <em>Settings &rarr; Display</em>.</td></tr>
 </tbody>
@@ -217,7 +217,7 @@
 <h2>Library Engagement &amp; Feedback Channels</h2>
 <div class="card">
 <ul>
-<li><strong>Product Roadmap Portal</strong> &mdash; vote on features from &ldquo;not important&rdquo; to &ldquo;critically important&rdquo; and add comments <em>(customer login required)</em></li>
+<li><strong>Public Roadmap</strong> &mdash; vote on features from &ldquo;not important&rdquo; to &ldquo;critically important&rdquo; and add comments</li>
 <li><strong>Idea Exchange</strong> &mdash; submit and vote on ideas
 <ul>
 <li>120+ users/day average</li>
@@ -232,10 +232,12 @@
 <!-- -->
 <h3>Links</h3>
 <ul>
-<li><a href="https://www.iii.com/resources/webinars/">Webinars &amp; Recordings</a></li>
-<li><a href="https://iii.com/roadmap/">Product Roadmap Portal</a> <em>(customer login required)</em></li>
-<li><a href="https://ideaexchange.iii.com/">Idea Exchange</a></li>
+<li><a href="https://www.iii.com/webinars/">Webinars</a></li>
+<li><a href="https://knowledge.ag-software.clarivate.com/kp/index.htm">Knowledge Portal</a></li>
+<li><a href="https://portal.productboard.com/iii/">Public Roadmap</a></li>
+<li><a href="https://ideas.iii.com/">Idea Exchange</a> <em>(login required only to post a new idea)</em></li>
 </ul>
+<p><em>All four channels are publicly available without a login.</em></p>
 </div>
 
 <h2>Slide Photos</h2>


### PR DESCRIPTION
## Summary

Applies the note corrections Mike Dicus (Clarivate, Manager Product Management — Innovative) sent on 2026-04-28 covering five pages of the IUG 2026 shared notes site. Each fix is captured in its own GitHub issue and its own commit.

| Page | Issue | Commit |
|------|-------|--------|
| Sierra Roadmap | #6 | `a71cc93` |
| Sierra Year in Review | #7 | `ea29077` |
| MEEP | #8 | `8dd1dd0` |
| Executive Leadership Panel | #9 | `fab8bed` |
| Sierra Sys Admin Forum | #10 | `bd7e758` |

Each issue body lists Mike's exact text alongside what was on the page; the per-issue verification comments document the cross-checks performed against the source content before edits were made.

## What changed

- **#6 Sierra Roadmap** — Removed Keycloak entry from May 2026 release row (it was from the SSO session, not Mike's roadmap session); fixed "Enhanced consortial workflow support" → "Enhance support for exhibitions in IMMS"; replaced the March 2026 MEEP voting results with Mike's correct three-item list.
- **#7 Sierra Year in Review** — Corrected SQS target from "Alma Starter" to "LX Starter"; replaced the Library Engagement & Feedback channel links with Mike's correct URLs (added the Knowledge Portal link, which was missing from the page entirely); removed the inaccurate "(customer login required)" caveat.
- **#8 MEEP** — Replaced the Sierra 6.6 winning-ideas list (previous text appeared to be a paraphrased / OCR-drift version) with Mike's confirmed values. The optional 2025 releases (6.4 / 6.5) Mike provided are **not** included here — that is a separate scope decision.
- **#9 Executive Leadership Panel** — Replaced the panelist list with Mike's confirmed eight panelists and titles. Updated body references: "Noel" → Yaniv Shmuel; "VP of Product Management" / "[Unnamed]" → Ashley Barey. **"Yoav" left in body text intentionally** — per Mike, that name in the transcript could refer to either Yoel Goldenberg or Yariv Kursh, and he wasn't in the room for most of the discussion to disambiguate. A note on the panelist card explains this; we'll need slide photos / recording / another attendee's notes to fully resolve it.
- **#10 Sierra Sys Admin Forum** — Single-spot spelling fix: "Dykus" → "Dicus" under "New API enhancement" in the Circ Active / Patron Record Updates section.

## Open follow-ups

- [ ] Decide whether to add Mike's 2025 Sierra release info (6.4 / 6.5) to the MEEP page.
- [ ] Reconcile the remaining "Yoav" body references on the Executive Panel page once we can confirm against slide photos / recording.

## Test plan

- [x] Built site locally (`uv run python build.py`) — 23 pages generated cleanly
- [x] Spot-checked rendered HTML for each of the 5 changed pages — all corrections present, no markup regressions
- [ ] Reviewer pass before squash-merge to master (auto-deploys to GitHub Pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)